### PR TITLE
Add lean-watermarks mixin

### DIFF
--- a/pytest_rally/elasticsearch.py
+++ b/pytest_rally/elasticsearch.py
@@ -32,7 +32,7 @@ class TestCluster:
                  revision="current",
                  http_port=19200,
                  node_name="rally-node",
-                 car="4gheap,trial-license,x-pack-ml",
+                 car="4gheap,trial-license,x-pack-ml,lean-watermarks",
                  debug=False):
         self.installation_id = None
         self.distribution_version = distribution_version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def make_conftest(pytester, repo):
     def pytest_addoption(parser):
         group = parser.getgroup("rally")
         group.addoption("--track-repository", action="store", default=None)
-        group.addoption("--track-revision", action="store", default="master")
+        group.addoption("--track-revision", action="store", default="main")
     """
     pytester.makeconftest(conftest_str)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -29,7 +29,7 @@ def test_runs_correct_race_commands(caplog, temp_repo, run):
     def expected_log_line(track, challenge):
         command = (
             f'esrally race --track="{track}" --challenge="{challenge}" '
-            f'--track-repository="{temp_repo}" --track-revision="master" '
+            f'--track-repository="{temp_repo}" --track-revision="main" '
             '--configuration-name="pytest" --enable-assertions --kill-running-processes '
             '--on-error="abort" --pipeline="benchmark-only" --target-hosts="127.0.0.1:19200" --test-mode'
         )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -45,3 +45,14 @@ def test_runs_correct_race_commands(caplog, temp_repo, run):
     res = run()
     actual = [(r.name, r.levelname, r.message) for r in caplog.records if "esrally race" in r.message]
     assert actual == expected
+
+def test_runs_correct_install_command(caplog, temp_repo, run):
+    expected = [
+        ("pytest_rally.elasticsearch", "DEBUG", 'Installing Elasticsearch: '
+         '[esrally install --quiet --http-port=19200 --node=rally-node --master-nodes=rally-node '
+         '--car=4gheap,trial-license,x-pack-ml,lean-watermarks --seed-hosts="127.0.0.1:19300" '
+         '--revision=current]')
+    ]
+    res = run()
+    actual = [(r.name, r.levelname, r.message) for r in caplog.records if "esrally install" in r.message]
+    assert actual == expected


### PR DESCRIPTION
This PR adds `lean-watermarks` mixin (depends on https://github.com/elastic/rally-teams/pull/80) to allow `pytest-rally` runs in environments with small disk resources.

The PR also fixes unit tests to reflect the right default branch of `main`, instead of `master`.

We lack proper development instructions for `pytest-rally`, here's what worked for me:
```
# installation
pyenv local 3.11.4
python3 -mvenv .venv
source .venv/bin/activate
pip install pytest
pip install esrally
pip install -e .

# unit tests
pytest
```