### PR TITLE
Strip whitespace from revision

### DIFF
--- a/pytest_rally/plugin.py
+++ b/pytest_rally/plugin.py
@@ -62,9 +62,9 @@ def pytest_cmdline_main(config):
         branches = run_command_with_output(cmd).split("\n")
         current = next(filter(lambda b: b.startswith("*"), branches))
         if "detached" in current:
-            return run_command_with_output(f'git -C {repo} rev-parse HEAD')
+            return run_command_with_output(f'git -C {repo} rev-parse HEAD').strip()
         else:
-            return current.split()[1]
+            return current.split()[1].strip()
 
     repo = config.getoption("--track-repository", str(config.rootdir))
     rev = config.getoption("--track-revision", current_branch(repo))

--- a/pytest_rally/plugin.py
+++ b/pytest_rally/plugin.py
@@ -62,7 +62,7 @@ def pytest_cmdline_main(config):
         branches = run_command_with_output(cmd).split("\n")
         current = next(filter(lambda b: b.startswith("*"), branches))
         if "detached" in current:
-            return run_command_with_output(f'git -C {repo} rev-parse HEAD').strip()
+            return run_command_with_output(f'git -C {repo} rev-parse HEAD').rstrip("\n")
         else:
             return current.split()[1].strip()
 


### PR DESCRIPTION
You can test this PR yourself (prior to https://github.com/elastic/rally/pull/1772 being merged) by applying this patch to your local rally-tracks checkout:
```diff
diff --git a/pyproject.toml b/pyproject.toml
index fae550f..c1f6ba9 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ exclude = [
 [tool.hatch.envs.default]
 dependencies = [
     "esrally[develop] @ git+https://github.com/elastic/rally.git@master",
-    "pytest-rally @ git+https://github.com/elastic/pytest-rally.git@main",
+    "pytest-rally @ file:///home/esbench/pytest-rally",
+    #"pytest-rally @ git+https://github.com/elastic/pytest-rally.git@main",
 ]
 
 [tool.hatch.envs.unit]
```

And using this invocation:
```
$ /home/esbench/rally-tracks
$ pip cache remove pytest_rally && hatch env prune  && hatch -v -e it run test
```

Relates https://github.com/elastic/rally/pull/1772