### PR TITLE
Remove Rally configuration file gracefully

### DIFF
--- a/pytest_rally/rally.py
+++ b/pytest_rally/rally.py
@@ -89,7 +89,10 @@ class Rally():
 
     def delete_config_file(self):
         self.logger.info("Removing Rally config from [%s]", self.config_location)
-        os.remove(self.config_location)
+        try:
+            os.remove(self.config_location)
+        except FileNotFoundError:
+            self.logger.warning("Rally config file not found at [%s]", self.config_location)
 
     def set_revision(self):
         self.revision = process.run_command_with_output(f"esrally --version").rstrip()


### PR DESCRIPTION
If Rally test sequence triggers ES installation and start but then has all races filtered, Rally INI file might not get created at all leading to `FileNotFoundError`. This fix handles this exception gracefully.